### PR TITLE
Fix zone info

### DIFF
--- a/Interface/AddOns/NDui/Modules/Infobar/Friends.lua
+++ b/Interface/AddOns/NDui/Modules/Infobar/Friends.lua
@@ -455,7 +455,7 @@ function info:FriendsPanel_UpdateButton(button)
 	if index <= onlineFriends then
 		local name, level, class, area, status = unpack(friendTable[index])
 		button.status:SetTexture(status)
-		local zoneColor = GetRealZoneText() == area and activeZone or inactiveZone
+		local zoneColor = GetAreaText() == area and activeZone or inactiveZone
 		local levelColor = B.HexRGB(GetQuestDifficultyColor(level))
 		local classColor = DB.ClassColors[class] or levelColor
 		button.name:SetText(format("%s%s|r %s%s", levelColor, level, B.HexRGB(classColor), name))
@@ -474,7 +474,7 @@ function info:FriendsPanel_UpdateButton(button)
 		if client == BNET_CLIENT_WOW then
 			local color = DB.ClassColors[class] or GetQuestDifficultyColor(1)
 			name = B.HexRGB(color)..charName
-			zoneColor = GetRealZoneText() == infoText and activeZone or inactiveZone
+			zoneColor = GetAreaText() == infoText and activeZone or inactiveZone
 		end
 		button.name:SetText(format("%s%s|r (%s|r)", DB.InfoColor, accountName, name))
 		button.zone:SetText(format("%s%s", zoneColor, infoText))

--- a/Interface/AddOns/NDui/Modules/Infobar/Guild.lua
+++ b/Interface/AddOns/NDui/Modules/Infobar/Guild.lua
@@ -88,7 +88,7 @@ function info:GuildPanel_UpdateButton(button)
 	local zonecolor = DB.GreyColor
 	if UnitInRaid(name) or UnitInParty(name) then
 		zonecolor = DB.InfoColor
-	elseif GetRealZoneText() == zone then
+	elseif GetAreaText() == zone then
 		zonecolor = "|cff4cff4c"
 	end
 	button.zone:SetText(zonecolor..zone)

--- a/Interface/AddOns/NDui/Modules/Infobar/Location.lua
+++ b/Interface/AddOns/NDui/Modules/Infobar/Location.lua
@@ -37,13 +37,13 @@ info.eventList = {
 }
 
 info.onEvent = function(self)
-	subzone = GetSubZoneText()
-	zone = GetZoneText()
+	subzone = GetMinimapZoneText()
+	zone = GetAreaText()
 	pvpType, _, faction = GetZonePVPInfo()
 	pvpType = pvpType or "neutral"
 
 	local r, g, b = unpack(zoneInfo[pvpType][2])
-	self.text:SetText((subzone ~= "") and subzone or zone)
+	self.text:SetText(subzone)
 	self.text:SetTextColor(r, g, b)
 end
 

--- a/Interface/AddOns/NDui/Plugins/yClassColors.lua
+++ b/Interface/AddOns/NDui/Plugins/yClassColors.lua
@@ -54,7 +54,7 @@ end
 local function updateGuildView()
 	currentView = currentView or GetCVar("guildRosterView")
 
-	local playerArea = GetRealZoneText()
+	local playerArea = GetAreaText()
 	local buttons = GuildRosterContainer.buttons
 
 	for _, button in ipairs(buttons) do
@@ -154,7 +154,7 @@ hooksecurefunc(C_FriendList, "SortWho", function(sortType)
 end)
 
 hooksecurefunc(WhoFrame.ScrollBox, "Update", function(self)
-	local playerZone = GetRealZoneText()
+	local playerZone = GetAreaText()
 	local playerGuild = GetGuildInfo("player")
 	local playerRace = UnitRace("player")
 


### PR DESCRIPTION
部分地区采用`GetZoneText`、`GetRealZoneText`、`GetSubZoneText`会返回错误的地名，例如`多恩诺加尔`-`地下堡行者总部`，`GetZoneText`和`GetRealZoneText`会返回`地下堡行者总部`，而`GetSubZoneText`会返回`nil`，更换为`GetAreaText`和`GetMinimapZoneText`即可返回正确的`多恩诺加尔`-`地下堡行者总部`，同时和公会列表、好友列表的地区名也能正确匹配。