### PR TITLE
Replace high-definition icon

### DIFF
--- a/Interface/AddOns/NDui/Core/ExtraGUI.lua
+++ b/Interface/AddOns/NDui/Core/ExtraGUI.lua
@@ -2502,14 +2502,13 @@ function G:SetupAvada()
 		profileButtons[i] = bu
 	end
 
-	local close = B.CreateButton(panel, 30, 30, true, "Interface\\RAIDFRAME\\ReadyCheck-NotReady")
+	local close = B.CreateButton(panel, 30, 30, true, "Atlas:common-icon-redx")
 	close:SetPoint("TOPRIGHT", -5, -5)
 	close:SetScript("OnClick", function()
 		panel:Hide()
 	end)
 
-	local load = B.CreateButton(panel, 30, 30, true, "Atlas:streamcinematic-downloadicon")
-	load.Icon:SetTexCoord(.27, .73, .27, .73)
+	local load = B.CreateButton(panel, 30, 30, true, "Atlas:Garr_Building-AddFollowerPlus")
 	load:SetPoint("LEFT", profileButtons[10], "RIGHT", 5, 0)
 	load.title = L["LoadProfile"]
 	B.AddTooltip(load, "ANCHOR_RIGHT", L["LoadProfileTip"], "info")
@@ -2525,7 +2524,7 @@ function G:SetupAvada()
 		updateProfileButtons()
 	end)
 
-	local save = B.CreateButton(panel, 30, 30, true, "Interface\\RAIDFRAME\\ReadyCheck-Ready")
+	local save = B.CreateButton(panel, 30, 30, true, "Atlas:common-icon-checkmark")
 	save:SetPoint("LEFT", load, "RIGHT", 5, 0)
 	save.title = L["SaveProfile"]
 	B.AddTooltip(save, "ANCHOR_RIGHT", L["SaveProfileTip"], "info")

--- a/Interface/AddOns/NDui/Core/Functions.lua
+++ b/Interface/AddOns/NDui/Core/Functions.lua
@@ -1375,7 +1375,7 @@ do
 
 	-- Handle collapse
 	local function updateCollapseTexture(texture, collapsed)
-		local atlas = collapsed and "Soulbinds_Collection_CategoryHeader_Expand" or "Soulbinds_Collection_CategoryHeader_Collapse"
+		local atlas = collapsed and "ui-questtrackerbutton-secondary-expand" or "ui-questtrackerbutton-secondary-collapse"
 		texture:SetAtlas(atlas, true)
 	end
 

--- a/Interface/AddOns/NDui/Core/ProfileGUI.lua
+++ b/Interface/AddOns/NDui/Core/ProfileGUI.lua
@@ -207,9 +207,9 @@ function G:CreateProfileBar(parent, index)
 	if index == 1 then
 		B.PixelIcon(icon, nil, true) -- character
 		SetPortraitTexture(icon.Icon, "player")
+		icon.Icon:SetTexCoord(.15, .85, .15, .85)
 	else
-		B.PixelIcon(icon, 235423, true) -- share
-		icon.Icon:SetTexCoord(.6, .9, .1, .4)
+		B.PixelIcon(icon, "Interface\\Icons\\RaceChange", true) -- share
 		icon.index = index
 		G:FindProfleUser(icon)
 		icon:SetScript("OnEnter", G.Icon_OnEnter)
@@ -234,21 +234,19 @@ function G:CreateProfileBar(parent, index)
 	note.title = L["ProfileName"]
 	B.AddTooltip(note, "ANCHOR_TOP", L["ProfileNameTip"], "info")
 
-	local reset = G:CreateProfileIcon(bar, 1, "Atlas:transmog-icon-revert", L["ResetProfile"], L["ResetProfileTip"])
+	local reset = G:CreateProfileIcon(bar, 1, "Atlas:common-icon-redx", L["ResetProfile"], L["ResetProfileTip"])
 	reset:SetScript("OnClick", G.Reset_OnClick)
 	bar.reset = reset
 
-	local apply = G:CreateProfileIcon(bar, 2, "Interface\\RAIDFRAME\\ReadyCheck-Ready", L["SelectProfile"], L["SelectProfileTip"])
+	local apply = G:CreateProfileIcon(bar, 2, "Atlas:common-icon-checkmark", L["SelectProfile"], L["SelectProfileTip"])
 	apply:SetScript("OnClick", G.Apply_OnClick)
 	bar.apply = apply
 
-	local download = G:CreateProfileIcon(bar, 3, "Atlas:streamcinematic-downloadicon", L["DownloadProfile"], L["DownloadProfileTip"])
-	download.Icon:SetTexCoord(.25, .75, .25, .75)
+	local download = G:CreateProfileIcon(bar, 3, "Atlas:ui-questtrackerbutton-secondary-collapse", L["DownloadProfile"], L["DownloadProfileTip"])
 	download:SetScript("OnClick", G.Download_OnClick)
 	bar.download = download
 
-	local upload = G:CreateProfileIcon(bar, 4, "Atlas:bags-icon-addslots", L["UploadProfile"], L["UploadProfileTip"])
-	upload.Icon:SetInside(nil, 6, 6)
+	local upload = G:CreateProfileIcon(bar, 4, "Atlas:ui-questtrackerbutton-secondary-expand", L["UploadProfile"], L["UploadProfileTip"])
 	upload:SetScript("OnClick", G.Upload_OnClick)
 	bar.upload = upload
 

--- a/Interface/AddOns/NDui/Modules/Bags/Core.lua
+++ b/Interface/AddOns/NDui/Modules/Bags/Core.lua
@@ -270,7 +270,7 @@ local function CloseOrRestoreBags(self, btn)
 end
 
 function module:CreateCloseButton(f)
-	local bu = B.CreateButton(self, 22, 22, true, "Interface\\RAIDFRAME\\ReadyCheck-NotReady")
+	local bu = B.CreateButton(self, 22, 22, true, "Atlas:common-icon-redx")
 	bu:RegisterForClicks("AnyUp")
 	bu.__owner = f
 	bu:SetScript("OnClick", CloseOrRestoreBags)
@@ -281,9 +281,7 @@ function module:CreateCloseButton(f)
 end
 
 function module:CreateAccountBankButton(f)
-	local bu = B.CreateButton(self, 22, 22, true, 235423)
-	bu.Icon:SetTexCoord(.6, .9, .1, .4)
-	bu.Icon:SetPoint("BOTTOMRIGHT", -C.mult, -C.mult)
+	local bu = B.CreateButton(self, 22, 22, true, "Interface\\Icons\\Factionchange")
 	bu:RegisterForClicks("AnyUp")
 	bu:SetScript("OnClick", function(_, btn)
 		if not C_Bank.CanViewBank(ACCOUNT_BANK_TYPE) then return end
@@ -336,7 +334,7 @@ function module:CreateAccountMoney()
 end
 
 function module:CreateBankButton(f)
-	local bu = B.CreateButton(self, 22, 22, true, "Atlas:Banker")
+	local bu = B.CreateButton(self, 22, 22, true, "Interface\\Icons\\Battleground_Strongbox_Gold_"..DB.MyFaction)
 	bu:SetScript("OnClick", function()
 		if not C_Bank.CanViewBank(CHAR_BANK_TYPE) then return end
 
@@ -358,8 +356,7 @@ local function updateAccountBankDeposit(bu)
 end
 
 function module:CreateAccountBankDeposit()
-	local bu = B.CreateButton(self, 22, 22, true, "Atlas:GreenCross")
-	bu.Icon:SetOutside()
+	local bu = B.CreateButton(self, 22, 22, true, "Interface\\Paperdollinfoframe\\Character-Plus")
 	bu:RegisterForClicks("AnyUp")
 	bu:SetScript("OnClick", function(_, btn)
 		if btn == "RightButton" then
@@ -381,8 +378,7 @@ function module:CreateAccountBankDeposit()
 end
 
 function module:CreateBankDeposit()
-	local bu = B.CreateButton(self, 22, 22, true, "Atlas:GreenCross")
-	bu.Icon:SetOutside()
+	local bu = B.CreateButton(self, 22, 22, true, "Interface\\Paperdollinfoframe\\Character-Plus")
 	bu:RegisterForClicks("AnyUp")
 	bu:SetScript("OnDoubleClick", function(_, btn)
 		if btn == "LeftButton" then
@@ -409,7 +405,7 @@ local function ToggleBackpacks(self)
 end
 
 function module:CreateBagToggle(click)
-	local bu = B.CreateButton(self, 22, 22, true, "Interface\\Buttons\\Button-Backpack-Up")
+	local bu = B.CreateButton(self, 22, 22, true, "Interface\\Icons\\inv_misc_bag_08")
 	bu.__owner = self
 	bu:SetScript("OnClick", ToggleBackpacks)
 	bu.title = BACKPACK_TOOLTIP
@@ -422,7 +418,7 @@ function module:CreateBagToggle(click)
 end
 
 function module:CreateSortButton(name)
-	local bu = B.CreateButton(self, 22, 22, true, "Interface\\Icons\\INV_Pet_Broom")
+	local bu = B.CreateButton(self, 22, 22, true, "Interface\\Icons\\Inv_Pet_Broom")
 	bu:SetScript("OnClick", function()
 		if C.db["Bags"]["BagSortMode"] == 3 then
 			UIErrorsFrame:AddMessage(DB.InfoColor..L["BagSortDisabled"])
@@ -561,9 +557,7 @@ function module:CreateSplitButton()
 	editbox:SetJustifyH("CENTER")
 	editbox:SetScript("OnTextChanged", saveSplitCount)
 
-	local bu = B.CreateButton(self, 22, 22, true, "Interface\\HELPFRAME\\ReportLagIcon-AuctionHouse")
-	bu.Icon:SetPoint("TOPLEFT", -1, 3)
-	bu.Icon:SetPoint("BOTTOMRIGHT", 1, -3)
+	local bu = B.CreateButton(self, 22, 22, true, "Interface\\Icons\\Ability_Monk_CounteractMagic")
 	bu.__turnOff = function()
 		B.SetBorderColor(bu.bg)
 		bu.text = nil
@@ -678,9 +672,7 @@ function module:CreateFavouriteButton()
 
 	local enabledText = DB.InfoColor..L["FavouriteMode Enabled"]
 
-	local bu = B.CreateButton(self, 22, 22, true, "Interface\\Common\\friendship-heart")
-	bu.Icon:SetPoint("TOPLEFT", -5, 2.5)
-	bu.Icon:SetPoint("BOTTOMRIGHT", 5, -1.5)
+	local bu = B.CreateButton(self, 22, 22, true, "Interface\\Icons\\PetBattle_Health")
 	bu.__turnOff = function()
 		B.SetBorderColor(bu.bg)
 		bu.text = nil
@@ -737,9 +729,7 @@ local customJunkEnable
 function module:CreateJunkButton()
 	local enabledText = DB.InfoColor..L["JunkMode Enabled"]
 
-	local bu = B.CreateButton(self, 22, 22, true, "Interface\\BUTTONS\\UI-GroupLoot-Coin-Up")
-	bu.Icon:SetPoint("TOPLEFT", C.mult, -3)
-	bu.Icon:SetPoint("BOTTOMRIGHT", -C.mult, -3)
+	local bu = B.CreateButton(self, 22, 22, true, "Interface\\Icons\\Spell_ChargePositive")
 	bu.__turnOff = function()
 		B.SetBorderColor(bu.bg)
 		bu.text = nil
@@ -794,9 +784,7 @@ local deleteEnable
 function module:CreateDeleteButton()
 	local enabledText = DB.InfoColor..L["DeleteMode Enabled"]
 
-	local bu = B.CreateButton(self, 22, 22, true, "Interface\\Buttons\\UI-GroupLoot-Pass-Up")
-	bu.Icon:SetPoint("TOPLEFT", 3, -2)
-	bu.Icon:SetPoint("BOTTOMRIGHT", -1, 2)
+	local bu = B.CreateButton(self, 22, 22, true, "Interface\\Icons\\Spell_ChargeNegative")
 	bu.__turnOff = function()
 		B.SetBorderColor(bu.bg)
 		bu.text = nil


### PR DESCRIPTION
替换 `个人资源条/职业监控` `背包/银行` `控制台` `收起/展开按钮` 图标为高清图标。

普通银行图标将根据阵营自动选择。

替换后效果：
<img width="438" height="96" alt="b1" src="https://github.com/user-attachments/assets/f49f7dda-2fee-4d11-a8de-82f1b9cea8b8" />
<img width="310" height="110" alt="b2" src="https://github.com/user-attachments/assets/0a899501-106b-498b-9106-c74308a7d44d" />
<img width="298" height="98" alt="b3" src="https://github.com/user-attachments/assets/f3b9e82f-d5e5-4ccb-8e42-1bbfe741cc4b" />
<img width="1216" height="600" alt="b4" src="https://github.com/user-attachments/assets/d5ef169d-a528-4e91-ada2-923bab1b8783" />
<img width="596" height="120" alt="b5" src="https://github.com/user-attachments/assets/3cd209b5-bf92-49a4-bc0a-4a50f1ef7e32" />
<img width="116" height="142" alt="b6" src="https://github.com/user-attachments/assets/1353f90d-dabe-471c-9ef1-5256f5d2f3cc" />
