### PR TITLE
feat(uframe): add energy tick ticker for Rogue and Feral Druid

### DIFF
--- a/Interface/AddOns/NDui/Libs/oUF/Plugins/EnergyTick.lua
+++ b/Interface/AddOns/NDui/Libs/oUF/Plugins/EnergyTick.lua
@@ -1,0 +1,94 @@
+local _, ns = ...
+local oUF = ns.oUF
+
+local UnitPower = UnitPower
+local UnitPowerMax = UnitPowerMax
+
+local function OnUpdate(self, elapsed)
+	local element = self.EnergyTick
+	if not element then return end
+
+	-- Don't animate if hidden or if it's not currently active
+	if not element:IsShown() then return end
+
+	element.timer = (element.timer or 0) + elapsed
+	
+	-- Reset the 2-second interval bounds
+	if element.timer >= 2 then
+		element.timer = element.timer % 2
+	end
+
+	-- Update the spark position based on the power bar's exact width
+	local barWidth = self.Power:GetWidth()
+	if barWidth > 0 then
+		local position = (element.timer / 2) * barWidth
+		element:SetPoint("CENTER", self.Power, "LEFT", position, 0)
+	end
+end
+
+local function Update(self, event, unit, powerType)
+	if self.unit ~= unit or (powerType and powerType ~= "ENERGY") then return end
+
+	local element = self.EnergyTick
+	if not element then return end
+
+	-- Use 3 for Energy type
+	local currentPower = UnitPower(unit, 3)
+
+	-- If energy has increased from what we last saw, the server just processed a tick
+	if event == "UNIT_POWER_UPDATE" then
+		if currentPower > (element.lastPower or 0) then
+			-- It ticked! Sync the visual spark back to the left side
+			element.timer = 0
+		end
+	end
+
+	element.lastPower = currentPower
+
+	-- Hide the spark gracefully when energy is completely full
+	if currentPower >= UnitPowerMax(unit, 3) then
+		element:SetAlpha(0)
+	else
+		element:SetAlpha(element.defaultAlpha or 1)
+	end
+end
+
+local function Path(self, ...)
+	return (self.EnergyTick.Override or Update)(self, ...)
+end
+
+local function Enable(self, unit)
+	local element = self.EnergyTick
+	if element and unit == "player" then
+		element.__owner = self
+		element.timer = 0
+		element.lastPower = UnitPower("player", 3)
+		
+		-- Fallback alpha configuration
+		element.defaultAlpha = element:GetAlpha() == 0 and 1 or element:GetAlpha()
+
+		-- Hook standard events
+		self:RegisterEvent("UNIT_POWER_UPDATE", Path)
+		self:RegisterEvent("UNIT_MAXPOWER", Path)
+		
+		-- Tie an OnUpdate script to the player's unitframe to animate it smoothly 
+		if not self.EnergyTickUpdateHooked then
+			self:HookScript("OnUpdate", OnUpdate)
+			self.EnergyTickUpdateHooked = true
+		end
+
+		element:Show()
+		return true
+	end
+end
+
+local function Disable(self)
+	local element = self.EnergyTick
+	if element then
+		element:Hide()
+		self:UnregisterEvent("UNIT_POWER_UPDATE", Path)
+		self:UnregisterEvent("UNIT_MAXPOWER", Path)
+	end
+end
+
+oUF:AddElement("EnergyTick", Path, Enable, Disable)

--- a/Interface/AddOns/NDui/Libs/oUF/oUF.xml
+++ b/Interface/AddOns/NDui/Libs/oUF/oUF.xml
@@ -36,6 +36,7 @@
 	<Script file='Plugins\FloatingCombatFeedback.lua' />
 	<Script file='Plugins\Swing.lua' />
 	<Script file='Plugins\RaidAuras.lua' />
+	<Script file='Plugins\EnergyTick.lua' />
 
 	<Script file="finalize.lua"/>
 </Ui>

--- a/Interface/AddOns/NDui/Modules/UFs/Elements/EnergyTick.lua
+++ b/Interface/AddOns/NDui/Modules/UFs/Elements/EnergyTick.lua
@@ -1,0 +1,27 @@
+local _, ns = ...
+local B, C, L, DB = unpack(ns)
+local oUF = ns.oUF
+local UF = B:GetModule("UnitFrames")
+
+function UF:CreateEnergyTick(self)
+	if self.mystyle ~= "player" then return end
+
+	local _, class = UnitClass("player")
+	if class ~= "ROGUE" and class ~= "DRUID" then return end
+
+	if not self.Power then return end
+
+	local spark = self.Power:CreateTexture(nil, "OVERLAY")
+	spark:SetTexture("Interface\\CastingBar\\UI-CastingBar-Spark")
+	spark:SetBlendMode("ADD")
+	
+	-- Base the spark off the official oUF Energy color (so it naturally blends)
+	-- but boost the alpha/brightness so it still pops against the bar
+	local energyColor = oUF.colors.power["ENERGY"] or {1, 1, 0}
+	spark:SetVertexColor(energyColor[1], energyColor[2], energyColor[3], 1.0)
+	
+	-- Make spark slightly taller than power bar
+	spark:SetSize(12, self.Power:GetHeight() * 2.2) 
+	
+	self.EnergyTick = spark
+end

--- a/Interface/AddOns/NDui/Modules/UFs/Spawns.lua
+++ b/Interface/AddOns/NDui/Modules/UFs/Spawns.lua
@@ -42,6 +42,7 @@ local function CreatePlayerStyle(self)
 		--UF:ReskinTimerTrakcer(self)
 	end
 	if C.db["Map"]["DisableMinimap"] or not C.db["Misc"]["ExpRep"] then UF:CreateExpRepBar(self) end
+	UF:CreateEnergyTick(self)
 end
 
 local function CreateTargetStyle(self)

--- a/Interface/AddOns/NDui/Modules/UFs/UFs.xml
+++ b/Interface/AddOns/NDui/Modules/UFs/UFs.xml
@@ -6,6 +6,7 @@
 	<Script file="Spawns.lua"/>
 
 	<Script file="Elements\Castbar.lua"/>
+	<Script file="Elements\EnergyTick.lua"/>
 	<Script file="Elements\RaidAuras.lua"/>
 	<Script file="Elements\AurasIndicator.lua"/>
 	<Script file="Elements\SpellsIndicator.lua"/>


### PR DESCRIPTION
First of this is a works for me implementation. Feel free to comment and improve this since this is my first work on this plugin.

NDUi was missing an energy ticker and i really didn't want to add another plugin just for this.

**What it does**
Shows the energy tick whenever a Rogue or a Druid is missing energy - hooks into power update and maxpower.

**Additions**
- Add oUF EnergyTick plugin for server-synced 2s intervals
- Add EnergyTick UI element using castbar spawk visual
- Integrated into player unitframe spawn logic

**Things to improve but not implemented**
- Option to customize the spark color and opacity or find a fitting one that seamlessly integrates into the design of NDui
- Do Rogues need this?
- I didn't bother to look into Settings Frames but maybe an option would be nice to disable this if someone is actually using another plugin for this?

```
# Interface/AddOns/NDui/Modules/UFs/Elements/EnergyTick.lua
local energyColor = oUF.colors.power["ENERGY"] or {1, 1, 0}
spark:SetVertexColor(energyColor[1], energyColor[2], energyColor[3], 1.0)
```
Im not sure if this is the right way to do this. Maybe find a better way to access the constants or one of the above?
