### PR TITLE
修复 InspectPVPFrame 无效单位错误 / Fix invalid InspectPVPFrame unit error

### DIFF
--- a/Interface/AddOns/NDui/Modules/Skins/Blizzard/Blizzard_InspectUI.lua
+++ b/Interface/AddOns/NDui/Modules/Skins/Blizzard/Blizzard_InspectUI.lua
@@ -1,6 +1,8 @@
 local _, ns = ...
 local B, C, L, DB = unpack(ns)
 
+local inspectPVPFrameUpdateHooked
+
 C.themes["Blizzard_InspectUI"] = function()
 	B.StripTextures(InspectModelFrame, true)
 	InspectGuildFrameBG:Hide()
@@ -8,6 +10,19 @@ C.themes["Blizzard_InspectUI"] = function()
 	InspectPaperDollFrame.ViewButton:ClearAllPoints()
 	InspectPaperDollFrame.ViewButton:SetPoint("TOP", InspectFrame, 0, -45)
 	InspectPVPFrame.BG:Hide()
+
+	if InspectPVPFrame_Update and not inspectPVPFrameUpdateHooked then
+		inspectPVPFrameUpdateHooked = true
+
+		local orig_InspectPVPFrame_Update = InspectPVPFrame_Update
+		InspectPVPFrame_Update = function(...)
+			local unit = InspectFrame and InspectFrame.unit
+			if type(unit) ~= "string" or unit == "" then return end
+
+			return orig_InspectPVPFrame_Update(...)
+		end
+	end
+
 	B.Reskin(InspectPaperDollItemsFrame.InspectTalents)
 
 	-- Character

--- a/Interface/AddOns/NDui/Modules/Tooltip/ItemLevel.lua
+++ b/Interface/AddOns/NDui/Modules/Tooltip/ItemLevel.lua
@@ -61,6 +61,7 @@ function TT:InspectOnUpdate(elapsed)
 	if self.elapsed > frequency then
 		self.elapsed = 0
 		self:Hide()
+		if InspectFrame and InspectFrame:IsShown() then return end
 		ClearInspectPlayer()
 
 		if currentUNIT and checkUnitGUID(currentUNIT) == currentGUID then


### PR DESCRIPTION
## 问题 / Problem

当被检查目标已不可用时，`Blizzard_InspectUI` 仍可能触发 `INSPECT_HONOR_UPDATE`。此时 `InspectPVPFrame_Update` 会把无效单位传给 `UnitFactionGroup` 并产生报错。

`Blizzard_InspectUI` may fire `INSPECT_HONOR_UPDATE` after the inspected unit is no longer available. `InspectPVPFrame_Update` can then pass an invalid unit to `UnitFactionGroup` and raise an error.

## 修改 / Changes

- 在 `InspectFrame.unit` 无效时跳过 `InspectPVPFrame_Update`。
- 检查窗口显示时，阻止提示装备等级更新器调用 `ClearInspectPlayer()`。
- Guard `InspectPVPFrame_Update` when `InspectFrame.unit` is invalid.
- Prevent the tooltip item-level updater from calling `ClearInspectPlayer()` while `InspectFrame` is shown.

## 验证 / Verification

- 已检查最终差异：2 个文件，核心逻辑新增 16 行和 2 行。
- 建议在游戏内打开检查窗口、切换 PVP 相关页面，并同时鼠标悬停其他玩家，确认不再出现 `UnitFactionGroup` 报错。
- Reviewed the final diff across both affected files.
- Suggested manual test: open InspectFrame, switch PVP-related views, and mouse over other players; confirm the `UnitFactionGroup` error no longer occurs.